### PR TITLE
Added ButtonState enum class and input handling methods

### DIFF
--- a/Space-Invaders/Header/Event/EventService.h
+++ b/Space-Invaders/Header/Event/EventService.h
@@ -3,17 +3,33 @@
 #include <SFML/Window/Event.hpp>
 
 namespace Event {
+
+	enum class ButtonState
+	{
+		PRESSED,
+		HELD,
+		RELEASED,
+	};
+
 	class EventService
 	{
 	private:
 		sf::Event gameEvent; //event variable
 		sf::RenderWindow* gameWindow; //ptr to our game window
 
+		ButtonState leftMouseButtonState;
+		ButtonState rightMouseButtonState;
+		ButtonState leftArrowButtonState;
+		ButtonState rightArrowButtonState;
+		ButtonState aButtonState;
+		ButtonState dButtonState;
+
 		bool IsGameWindowOpen() const;
 		bool GameWindowWasClosed() const; //for the condition we already had - the title bar cross.
 		bool HasQuitGame() const; //for our new 'ESC' condition
 
-
+		void UpdateMouseButtonsState(ButtonState& currentButtonState, sf::Mouse::Button mouseButton) const;
+		void UpdateKeyboardButtonsState(ButtonState& currentButtonState, sf::Keyboard::Key keyboardButton) const;
 
 	public:
 		EventService();
@@ -30,6 +46,9 @@ namespace Event {
 
 		bool PressedLeftMouseButton() const;
 		bool PressedRightMouseButton() const;
+
+		bool PressedAKey() const;
+		bool PressedDKey() const;
 
 	};
 }

--- a/Space-Invaders/Source/Event/EventService.cpp
+++ b/Space-Invaders/Source/Event/EventService.cpp
@@ -15,6 +15,12 @@ namespace Event {
     void EventService::Update()
     {
         ProcessEvents();
+        UpdateMouseButtonsState(leftMouseButtonState, sf::Mouse::Left);
+        UpdateMouseButtonsState(rightMouseButtonState, sf::Mouse::Right);
+        UpdateKeyboardButtonsState(leftArrowButtonState, sf::Keyboard::Left);
+        UpdateKeyboardButtonsState(rightArrowButtonState, sf::Keyboard::Right);
+        UpdateKeyboardButtonsState(aButtonState, sf::Keyboard::A);
+        UpdateKeyboardButtonsState(dButtonState, sf::Keyboard::D);
     }
 
     void EventService::ProcessEvents()
@@ -30,6 +36,46 @@ namespace Event {
         }
     }
 
+    void EventService::UpdateMouseButtonsState(ButtonState& currentButtonState, sf::Mouse::Button mouseButton) const
+    {
+        if (sf::Mouse::isButtonPressed(mouseButton))
+        {
+            switch (currentButtonState)
+            {
+            case ButtonState::RELEASED:
+                currentButtonState = ButtonState::PRESSED;
+                break;
+            case ButtonState::PRESSED:
+                currentButtonState = ButtonState::HELD;
+                break;
+            }
+        }
+        else
+        {
+            currentButtonState = ButtonState::RELEASED;
+        }
+    }
+
+    void EventService::UpdateKeyboardButtonsState(ButtonState& currentButtonState, sf::Keyboard::Key keyboardButton) const
+    {
+        if (sf::Keyboard::isKeyPressed(keyboardButton))
+        {
+            switch (currentButtonState)
+            {
+            case ButtonState::RELEASED:
+                currentButtonState = ButtonState::PRESSED;
+                break;
+            case ButtonState::PRESSED:
+                currentButtonState = ButtonState::HELD;
+                break;
+            }
+        }
+        else
+        {
+            currentButtonState = ButtonState::RELEASED;
+        }
+    }
+
     bool EventService::HasQuitGame() const { return (IsKeyboardEvent() && PressedEscapeKey()); } // only true if the ESC key is pressed and a keyboard event has been registered
 
     //checks for if a keyboard key has been pressed
@@ -42,22 +88,16 @@ namespace Event {
 
     bool EventService::GameWindowWasClosed() const { return gameEvent.type == sf::Event::Closed; }
 
-    bool EventService::PressedLeftKey() const { return gameEvent.key.code == sf::Keyboard::Left; }
+    bool EventService::PressedLeftKey() const { return leftArrowButtonState == ButtonState::HELD; }
 
-    bool EventService::PressedRightKey() const { return gameEvent.key.code == sf::Keyboard::Right; }
+    bool EventService::PressedRightKey() const { return rightArrowButtonState == ButtonState::HELD; }
 
-    bool EventService::PressedLeftMouseButton() const
-    {
-        // check if a mouse button was pressed and which mouse button it was
-        return gameEvent.type == sf::Event::MouseButtonPressed && gameEvent.mouseButton.button == sf::Mouse::Left;
-    }
+    bool EventService::PressedAKey() const { return aButtonState == ButtonState::HELD; }
 
-    bool EventService::PressedRightMouseButton() const
-    {
-        /*
-        // same as above for the right button, if we want to we can move the mouse button
-        // press check to another function altogether.
-        */
-        return gameEvent.type == sf::Event::MouseButtonPressed && gameEvent.mouseButton.button == sf::Mouse::Right;
-    }
+    bool EventService::PressedDKey() const { return dButtonState == ButtonState::HELD; }
+
+
+    bool EventService::PressedLeftMouseButton() const { return leftMouseButtonState == ButtonState::PRESSED; }
+
+    bool EventService::PressedRightMouseButton() const { return rightMouseButtonState == ButtonState::PRESSED; }
 }

--- a/Space-Invaders/Source/Player/PlayerController.cpp
+++ b/Space-Invaders/Source/Player/PlayerController.cpp
@@ -7,6 +7,7 @@
 
 namespace Player {
 	using namespace Global;
+	using namespace Event;
 	PlayerController::PlayerController()
 	{
 		playerView = new PlayerView();
@@ -43,13 +44,14 @@ namespace Player {
 
 	void PlayerController::ProcessPlayerInput()
 	{
-		// we will move this to event service at a later time
-		if ((sf::Keyboard::isKeyPressed(sf::Keyboard::Left)))
+		EventService* eventService = ServiceLocator::GetInstance()->GetEventService();
+
+		if (eventService->PressedLeftKey() || eventService->PressedAKey())
 		{
 			MoveLeft();
 		}
-		// we will move this to event service at a later time
-		if ((sf::Keyboard::isKeyPressed(sf::Keyboard::Right)))
+
+		if (eventService->PressedRightKey() || eventService->PressedDKey())
 		{
 			MoveRight();
 		}


### PR DESCRIPTION
- Added enum class ButtonState (PRESSED, HELD, RELEASED) in EventService.h.
- Declared private ButtonState variables for input buttons excluding 'ESC' (e.g., 'A', 'D').
- Implemented void methods to update mouse and keyboard button states separately.
- Updated mouseButtonClick() to use PRESSED state instead of direct checks.
- Updated keyboardButtonClick() to use HELD state for continuous input.
- Added public bool methods to check if 'A' and 'D' were pressed.
- Integrated new EventService functionality in PlayerController.cpp.
- Called update functions for each ButtonState variable in update().